### PR TITLE
fix: add missing index definition in getElement()

### DIFF
--- a/src/Hashtable.h
+++ b/src/Hashtable.h
@@ -463,6 +463,7 @@ public:
      * @return The value associated with the key, or a default constructed object if key not found.
     */
     V getElement(const K& key) const {
+        int index = calculateIndex(key, TABLE_SIZE);
         Entry* entry = table[index];
         while (entry != nullptr) {
             if (entry->key == key) {


### PR DESCRIPTION
Hey Brayden! I wanted to try your library for an arduino project, and experienced an issue upon building. It came down to the definition of `index` missing in a function of `Hashtable.h`, so I thought I might reach out. 

I was unsure if it should be `calculateIndex(key, TABLE_SIZE);` or `int index = hash(key);`, but i figured they do the same. Please do correct my change if I missunderstood something.

Best wishes.